### PR TITLE
izitoast.d.ts has export now.

### DIFF
--- a/dist/izitoast/izitoast.d.ts
+++ b/dist/izitoast/izitoast.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Tarık İNCE <incetarik@hotmail.com> and Marcelo Dolce <dolcemarcelo@gmail.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped 
 
-type IziToastPosition = "bottomRight" | "bottomLeft" | "topRight" | "topLeft" | "topCenter" | "bottomCenter" | "center"
-type IziToastTransitionIn = "bounceInLeft" | "bounceInRight" | "bounceInUp" | "bounceInDown" | "fadeIn" | "fadeInDown" | "fadeInUp" | "fadeInLeft" | "fadeInRight" | "flipInX"
-type IziToastTransitionOut = "fadeOut" | "fadeOutUp" | "fadeOutDown" | "fadeOutLeft" | "fadeOutRight" | "flipOutX"
+type IziToastPosition = "bottomRight" | "bottomLeft" | "topRight" | "topLeft" | "topCenter" | "bottomCenter" | "center";
+type IziToastTransitionIn = "bounceInLeft" | "bounceInRight" | "bounceInUp" | "bounceInDown" | "fadeIn" | "fadeInDown" | "fadeInUp" | "fadeInLeft" | "fadeInRight" | "flipInX";
+type IziToastTransitionOut = "fadeOut" | "fadeOutUp" | "fadeOutDown" | "fadeOutLeft" | "fadeOutRight" | "flipOutX";
 
 interface IziToastSettings {
     /**
@@ -258,4 +258,10 @@ interface IziToast {
     settings(settings: IziToastSettings): void;
 }
 
-declare var iziToast: IziToast
+declare var iziToast: IziToast;
+
+declare module "iziToast"
+{
+    export = iziToast;
+    
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "email": "dolcemarcelo@gmail.com",
     "homepage": "http://www.marcelodolce.com"
   },
+  "typings": "dist/izitoast/izitoast.d.ts",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/dolce/iziToast/issues"


### PR DESCRIPTION
I changed your izitoast.d.ts based on [toastr definition file](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/toastr/index.d.ts)

so now everyone can use it 
`import * as izi from 'iziToast';`

but It is necessary to create @types/izitoast for your definition file because typescript compiler checks `node_module/@types` folder.
