### PR TITLE
Add 'closeOnClick' option support

### DIFF
--- a/src/js/iziToast.js
+++ b/src/js/iziToast.js
@@ -78,6 +78,7 @@
 		balloon: false,
 		close: true,
 		closeOnEscape: false,
+		closeOnClick: false,
 		rtl: false,
 		position: 'bottomRight', // bottomRight, bottomLeft, topRight, topLeft, topCenter, bottomCenter, center
 		target: '',
@@ -1178,6 +1179,12 @@
 				if(evt.keyCode == 27) {
 				    that.hide(settings, $DOM.toast, 'esc');
 				}
+			});
+		}
+		
+		if(settings.closeOnClick) {
+			$DOM.toast.addEventListener('click', function (evt) {
+				that.hide($DOM.toast, settings, 'toast');
 			});
 		}
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -113,6 +113,11 @@ interface IziToastSettings {
      */
     closeOnEscape ?: boolean;
     /**
+     * Allows to close toast by clicking itself.
+     * Default value: false
+     */
+    closeOnClick ?: boolean;
+    /**
      * RTL option
      * Default value: false
      */


### PR DESCRIPTION
It allows the toast to be closed by clicking on the toast itself.
The default value of the 'closeOnClick' option is false.